### PR TITLE
Update priv_auc.assignmnetThreshold_v6.R

### DIFF
--- a/R/priv_auc.assignmnetThreshold_v6.R
+++ b/R/priv_auc.assignmnetThreshold_v6.R
@@ -56,7 +56,7 @@
     skipGlobal <- FALSE
 
     # aucThrs["outlierOfGlobal"] <- meanAUC + 2*sdAUC
-    aucThrs["outlierOfGlobal"] <- qnorm(1-(thrP/nCells), mean=meanAUC, sd=sdAUC)
+    aucThrs["outlierOfGlobal"] <- qnorm(1-((thrP*nCells)/nCells), mean=meanAUC, sd=sdAUC)
   }
 
   #V6


### PR DESCRIPTION
corrected "outlierOfGlobal" calculation in case AUC values follow a normal Distribution (maybeNormalDistr returns TRUE).