### PR TITLE
Update priv_auc.assignmnetThreshold_v6.R

### DIFF
--- a/R/priv_auc.assignmnetThreshold_v6.R
+++ b/R/priv_auc.assignmnetThreshold_v6.R
@@ -56,7 +56,7 @@
     skipGlobal <- FALSE
 
     # aucThrs["outlierOfGlobal"] <- meanAUC + 2*sdAUC
-    aucThrs["outlierOfGlobal"] <- qnorm(1-(thrP/nCells), mean=meanAUC, sd=sdAUC)
+    aucThrs["outlierOfGlobal"] <- qnorm(1-thrP, mean=meanAUC, sd=sdAUC)
   }
 
   #V6


### PR DESCRIPTION
corrected calculation of "outlierOfGlobal" in case AUC values follow a normal distribution (maybeNormalDistr returns TRUE)